### PR TITLE
Use `cargo diet` to limit packaged files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://ryanobeirne.github.io/deltae"
 homepage = "https://github.com/ryanobeirne/deltae"
 repository = "https://github.com/ryanobeirne/deltae.git"
 readme = "README.md"
+include = ["src/**/*", "LICENSE", "README.md"]
 
 # [[example]]
 # name = "deltae"


### PR DESCRIPTION
While vendoring this crate I noticed the docs are included in the package files.   I ran `cargo diet` to generate an `include` directive for `Cargo.toml` so that only relevant files are included in the published crate.  This reduces the size of the published crate by 98%.